### PR TITLE
Regex to filter in-game messages for Nexus and alike

### DIFF
--- a/SEDiscordBridge.sln
+++ b/SEDiscordBridge.sln
@@ -5,19 +5,6 @@ VisualStudioVersion = 15.0.28010.2016
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SEDiscordBridge", "SEDiscordBridge\SEDiscordBridge.csproj", "{D6D9214A-9E67-4A51-A148-A05D45AA5479}"
 EndProject
-Project("{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}") = "Torch.Server", "..\..\..\SpaceEngineersDedicado\torch-server\Torch.Server.exe", "{46B444E4-2EA1-4E8A-B0D9-413D3EED096A}"
-	ProjectSection(DebuggerProjectSystem) = preProject
-		PortSupplier = 00000000-0000-0000-0000-000000000000
-		Executable = D:\SpaceEngineersDedicado\torch-server\Torch.Server.exe
-		RemoteMachine = FABIO-PC
-		StartingDirectory = D:\SpaceEngineersDedicado\torch-server
-		Environment = Default
-		LaunchingEngine = 00000000-0000-0000-0000-000000000000
-		UseLegacyDebugEngines = No
-		LaunchSQLEngine = No
-		AttachLaunchAction = No
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,12 +27,6 @@ Global
 		{D6D9214A-9E67-4A51-A148-A05D45AA5479}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D6D9214A-9E67-4A51-A148-A05D45AA5479}.Release|x64.ActiveCfg = Release|Any CPU
 		{D6D9214A-9E67-4A51-A148-A05D45AA5479}.Release|x64.Build.0 = Release|Any CPU
-		{46B444E4-2EA1-4E8A-B0D9-413D3EED096A}.Debug|Any CPU.ActiveCfg = Release
-		{46B444E4-2EA1-4E8A-B0D9-413D3EED096A}.Debug|x64.ActiveCfg = Release
-		{46B444E4-2EA1-4E8A-B0D9-413D3EED096A}.No Torch|Any CPU.ActiveCfg = Release
-		{46B444E4-2EA1-4E8A-B0D9-413D3EED096A}.No Torch|x64.ActiveCfg = Release
-		{46B444E4-2EA1-4E8A-B0D9-413D3EED096A}.Release|Any CPU.ActiveCfg = Release
-		{46B444E4-2EA1-4E8A-B0D9-413D3EED096A}.Release|x64.ActiveCfg = Release
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SEDiscordBridge/SEDBConfig.cs
+++ b/SEDiscordBridge/SEDBConfig.cs
@@ -47,6 +47,9 @@ namespace SEDiscordBridge
         private bool _serverToDiscord = false;
         public bool ServerToDiscord { get => _serverToDiscord; set => SetValue(ref _serverToDiscord, value); }
 
+        string _serverToDiscordFilter = "";
+        public string ServerToDiscordFilter { get => _serverToDiscordFilter; set => SetValue(ref _serverToDiscordFilter, value); }
+
         private string _serverName = "Server";
         public string ServerName { get => _serverName; set => SetValue(ref _serverName, value); }
 

--- a/SEDiscordBridge/SEDBControl.xaml
+++ b/SEDiscordBridge/SEDBControl.xaml
@@ -60,6 +60,10 @@
             <Label Content="Discord Messages Server Name"/>
         </StackPanel>
         <CheckBox Content="Server outputs to Discord" Margin="3" IsChecked="{Binding ServerToDiscord}" ToolTip="Send any in-game Server outputs to Discord?"/>
+        <StackPanel Orientation="Horizontal" IsEnabled="{Binding ServerToDiscord}">
+            <TextBox Width="180" Text="{Binding ServerToDiscordFilter}" Margin="3" />
+            <Label Content="Ignored server output author (name) regular expression"/>
+        </StackPanel>
         <CheckBox Content="Receive Other BOT Messages" Margin="3" IsChecked="{Binding BotToGame}" ToolTip="Receive and send bot messages to in-game?"/>
 
         <Label Height="20">

--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -120,7 +120,11 @@ namespace SEDiscordBridge
                             break;
                     }
                 }
-                else if (Config.ServerToDiscord && msg.Channel.Equals(ChatChannel.Global) && !msg.Message.StartsWith(Config.CommandPrefix) && msg.Target.Equals(0))
+                else if (Config.ServerToDiscord &&
+                         msg.Channel.Equals(ChatChannel.Global) && 
+                         !msg.Message.StartsWith(Config.CommandPrefix) &&
+                         msg.Target.Equals(0) &&
+                         !ServerToDiscordFilterMatch(msg))
                 {
                     if(DEBUG) {
                         Log.Info($"Recieved messages with no SID {msg.Author} | {msg.Message} | {msg.Target}");
@@ -132,6 +136,13 @@ namespace SEDiscordBridge
             {
                 Log.Fatal(e);
             }
+        }
+
+        private bool ServerToDiscordFilterMatch(TorchChatMessage msg)
+        {
+            if (string.IsNullOrEmpty(Config.ServerToDiscordFilter)) return false;
+            
+            return new Regex(Config.ServerToDiscordFilter).IsMatch(msg.Author);
         }
 
         private void SessionChanged(ITorchSession session, TorchSessionState state)


### PR DESCRIPTION
Nexus' "bundled" Discord client isn't perfect and we had to opt out to using SEDB for certain server messages etc. The problem is that it causes Discord messages to duplicate when multiple Nexus instances are connected to the same Discord channel. 

![image](https://user-images.githubusercontent.com/5270319/176428568-d470102e-60ce-4eb6-b6e3-704b756c4a45.png)

This PR will introduce a regex config property which allows admins to filter out server messages in game, which can be used to prevent the duplicate messages from taking place.

![image](https://user-images.githubusercontent.com/5270319/176428712-5a9a8859-1fd4-4541-b221-a90523eb72cc.png)

![image](https://user-images.githubusercontent.com/5270319/176428535-fde6e03d-f5cd-42ce-a627-2c5512c663ce.png)
