### PR TITLE
Move the reflection to the first game tick when all plugins are loaded

### DIFF
--- a/SEDiscordBridge/SEDiscordBridgePlugin.cs
+++ b/SEDiscordBridge/SEDiscordBridgePlugin.cs
@@ -58,6 +58,16 @@ namespace SEDiscordBridge
 
         public void Save() => _config?.Save();
 
+        private bool Reflected = false;
+        public override void Update()
+        {
+            if (!Reflected && Config.LoadRanks)
+            {
+                ReflectEssentials();
+                Reflected = true;
+            }
+        }
+
 
         /// <inheritdoc />
         public override void Init(ITorchBase torch)
@@ -281,8 +291,8 @@ namespace SEDiscordBridge
             if (DDBridge == null)
                 DDBridge = new DiscordBridge(this);
 
-            if (Config.LoadRanks)
-                ReflectEssentials();
+         //   if (Config.LoadRanks)
+           //     ReflectEssentials();
 
             if (Config.BotToken.Length <= 0)
             {


### PR DESCRIPTION
Havent tested this, but with the reflection being in the first game tick the essentials plugin doesnt need to be listed as a dependency in the manifest, so it will load without it 