### PR TITLE
Fix permission checks to work with more then one user

### DIFF
--- a/SEDiscordBridge/DiscordBridge.cs
+++ b/SEDiscordBridge/DiscordBridge.cs
@@ -308,18 +308,17 @@ namespace SEDiscordBridge
                         if (Plugin.Config.CommandPerms.Count() > 0)
                         {
                             var userId = e.Author.Id.ToString();
-                            bool hasRolePerm = e.Guild.GetMemberAsync(e.Author.Id).Result.Roles.Where(r => Plugin.Config.CommandPerms.Where(c => c.Split(':')[0].Equals(r.Id.ToString())).Any()).Any();
+                            var roleIds = e.Guild.GetMemberAsync(e.Author.Id).Result.Roles.Select(r => r.Id.ToString()).ToList();
 
-                            if (Plugin.Config.CommandPerms.Where(c =>
+                            if (Plugin.Config.CommandPerms.Any(c =>
                             {
-                                if (!hasRolePerm && !c.Split(':')[0].Equals(userId))
+                                var AllowedId = c.Split(':')[0];
+                                var AllowedCommand = c.Split(':')[1];
+                                if ((AllowedId.Equals(userId) || roleIds.Contains(AllowedId)) && (AllowedCommand.Equals(cmd) || AllowedCommand.Equals("*")))
                                     return true;
-                                else
-                                if ((c.Split(':')[0].Equals(userId) || hasRolePerm) && (c.Split(':')[1].Equals(cmd) || c.Split(':')[1].Equals("*")))
-                                    return false;
 
-                                return true;
-                            }).Any())
+                                return false;
+                            }) == false)
                             {
                                 SendCmdResponse($"No permission for command: {cmd}", e.Channel, DiscordColor.Red, cmd);
                                 return Task.CompletedTask;


### PR DESCRIPTION
Previously, the permissions would check if any condition failed, rather then checking if any condition succeeded. This made it practically impossible to setup fine-grained permissions per-user or per-command.

Now, the check will succeed if any permission entry matches, either for a role or a user id, as well as the command.